### PR TITLE
Fix `next() called multiple times`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,8 @@ export default function (options: Options) {
             },
           }) as any
         )(ctx, next);
-      } else {
-        await next();
       }
     }
+    await next();
   };
 }


### PR DESCRIPTION
當 multiple config 的時候
例如:
```js
 config.proxy = {
    '/api1': {
        target: 'http://github.com/api1',
        changeOrigin: true,
        secure: false,
        pathRewrite: { '^/api1': '' },
    },
    '/api2': {
      target: 'http://github.com/api2',
      changeOrigin: true,
      secure: false,
      pathRewrite: { '^/api2': '' },
    },
    '/api3': {
      target: 'http://github.com/api1',
      changeOrigin: true,
      secure: false,
      pathRewrite: { '^/api3': '' },
    },
  };
```
訪問自身的router/controller 會報出

> ``nodejs.Error: next() called multiple times``

我嘗試這樣修改后可以Fix,但是我對node/egg不太熟...也不知道是不是對的